### PR TITLE
Enable serialize and deserialise for `Trace` and `SegySettings` in core.

### DIFF
--- a/giga-segy-core/Cargo.toml
+++ b/giga-segy-core/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["geo", "SEG-Y", "SEGY", "seismic"]
 license = "MIT OR Apache-2.0"
 links = ""
 repository = "https://github.com/GiGainfosystems/giga-segy"
-version = "0.3.1"
+version = "0.3.2"
 
 [lib]
 name = "giga_segy_core"

--- a/giga-segy-core/src/header_structs.rs
+++ b/giga-segy-core/src/header_structs.rs
@@ -284,6 +284,7 @@ pub struct BinHeader {
 /// It appears that this is stored mostly as character bytes (u8).
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TapeLabel {
     /// Bytes 1-4 (0..4)
     pub storage_unit_seq_no: [u8; 4],

--- a/giga-segy-core/src/lib.rs
+++ b/giga-segy-core/src/lib.rs
@@ -38,7 +38,7 @@ pub const CDPY_BYTE_LOCATION: usize = 184;
 ///
 /// The Header is parsed and stored in the structure, the data is stored
 /// in a memory map and referenced here as start and end indices.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Trace {

--- a/giga-segy-core/src/lib.rs
+++ b/giga-segy-core/src/lib.rs
@@ -40,6 +40,7 @@ pub const CDPY_BYTE_LOCATION: usize = 184;
 /// in a memory map and referenced here as start and end indices.
 #[derive(Debug, Clone)]
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Trace {
     /// A parsed trace header which contains the trace metadata.
     pub(crate) trace_header: TraceHeader,

--- a/giga-segy-core/src/settings.rs
+++ b/giga-segy-core/src/settings.rs
@@ -14,7 +14,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 /// This structure holds a list of various settings to be imported for the custom reading of
 /// byte locations of various variables in the headers and other things when interpreting a SEG-Y file.
 ///

--- a/giga-segy-in/Cargo.toml
+++ b/giga-segy-in/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = ["geo", "SEG-Y", "SEGY", "seismic", "parser"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/GiGainfosystems/giga-segy"
-version = "0.3.1"
+version = "0.3.2"
 
 [lib]
 name = "giga_segy_in"

--- a/giga-segy-out/Cargo.toml
+++ b/giga-segy-out/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = ["geo", "SEG-Y", "SEGY", "seismic", "writer"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/GiGainfosystems/giga-segy"
-version = "0.3.1"
+version = "0.3.2"
 
 [lib]
 name = "giga_segy_out"


### PR DESCRIPTION
This is needed for new gst3_api. This way we will be able to transparently pass the `giga_segy_core::{Trace, SegySettings}` to the new api.
(Primarily for the parser api)